### PR TITLE
Limit max payout a user can receive from a single game, to discourage…

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,6 +15,9 @@ var parseForm = bodyParser.urlencoded({ extended: false });
 // Put account info here
 var steemAcct = {username: 'steemretro', activeKey: '55'};
 
+// Maximum payout a user can recieve from a single game
+var MAX_PAYOUT = .01
+
 var app = express();
 
 app.use(logger('dev'));
@@ -82,6 +85,7 @@ app.post('/savescore', parseForm, csrfProtection, function (req, res, next) {
         res.status(500).send({success: false});
       } else {
         var gameEarnings = Number((s / 1000000) < 0.001 ? 0.001 : s / 1000000).toFixed(3);
+        gameEarnings = Math.min(gameEarnings, MAX_PAYOUT);
         var transferMsg = "Congratulations on achieving a highscore of " + s + " on level " + l + " at SteemPacman! Your earnings are " + gameEarnings + " STEEM.";
         steem.broadcast.transfer(steemAcct.activeKey, steemAcct.username, n, gameEarnings + ' STEEM', transferMsg, function(err, result){
           console.log(err ? err : result);


### PR DESCRIPTION
… cheating. Temporary workaround.

This PR limits the max payout a user can receive from a single game to 0.01 Steem. This prevents a user from using a single cURL replay attack in order to steal Steem. Users can still spam cURL attacks in order to steal small amounts of Steem repeatedly. A more permanent solution is needed in the future.